### PR TITLE
Fix ID's being added to downloaded contextpacks' wordlists

### DIFF
--- a/client/src/app/contextpacks/contextpack-card.component.ts
+++ b/client/src/app/contextpacks/contextpack-card.component.ts
@@ -18,7 +18,7 @@ export class ContextPackCardComponent implements OnInit {
 
 
   downloadJson(myJson: ContextPack, topic: string){
-    const sJson = JSON.stringify(myJson, null, 1);
+    const sJson = JSON.stringify(myJson, null, 2);
     const element = document.createElement('a');
     element.setAttribute('href', 'data:text/json;charset=UTF-8,' + encodeURIComponent(sJson));
     element.setAttribute('download', topic + '.json');

--- a/server/src/main/java/umm3601/contextpack/Word.java
+++ b/server/src/main/java/umm3601/contextpack/Word.java
@@ -1,7 +1,6 @@
 package umm3601.contextpack;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 

--- a/server/src/main/java/umm3601/contextpack/Wordlist.java
+++ b/server/src/main/java/umm3601/contextpack/Wordlist.java
@@ -6,9 +6,6 @@ import org.mongojack.Id;
 import org.mongojack.ObjectId;
 
 public class Wordlist {
-  @ObjectId @Id
-  public String _id;
-
   public String name;
   public boolean enabled;
   public ArrayList<Word> nouns;


### PR DESCRIPTION
Whenever you'd download a context pack all the wordlists would have null ID's instead of just having no ID tag at all so we've fixed that. Also changed our database seed to be in the format our client wants.